### PR TITLE
Update to handle Rails 6 parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ Just add this gem to your Gemfile and `has_secure_password` will start to use `a
 
 If you already have users authenticating with Rails' version of `has_secure_password`, this gem will automatically upgrade users to `argon2` during their next login.  In this case, please leave `bcrypt` installed to support he upgrade process.
 
+## Different Attributes
+
+If you are using Rails 6+, you can secure an attribute other than `password`.  Simply pass the attribute name as the first argument:
+
+```
+has_secure_password :recovery_password, validations: false
+```
+
+This gem also adds a simpler alias, `has_secure`. The same code could read as:
+
+```
+has_secure :recovery_password, validations: false
+```
+
+## Configuration
+
+Argon2 allows for several options which can be set in an initializer.
+
+For example, in `config/initializers/has_secure_password_argon2.rb`
+
+```
+HasSecurePasswordArgon2.time_cost = 2 # Default is 2. Can be 1..10
+HasSecurePasswordArgon2.memory_cost = 16 # Default is 16. Can be 1..31
+HasSecurePasswordArgon2.secret = ENV['ARGON2_SECRET'] # Default nil. Set this to the output of `rails secret' for added security
+```
+
+Read more about the [Argon2 options here](https://github.com/technion/ruby-argon2).
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/venables/has_secure_password_argon2. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/has_secure_password_argon2.rb
+++ b/lib/has_secure_password_argon2.rb
@@ -18,61 +18,106 @@ module HasSecurePasswordArgon2
   self.memory_cost = 16 # 1..31
 
   module ClassMethods
-    def has_secure_password(options = {})
-      super options
-      include InstanceMethodsOnActivation
-    end
-  end
+    def has_secure_password(attribute = :password, validations: true)
+      args = if ActiveRecord::VERSION::MAJOR >= 6
+               [attribute, validations: validations]
+             else
+               [validations: validations]
+             end
 
-  module InstanceMethodsOnActivation
-    # Returns +self+ if the password is correct, otherwise +false+.
-    #
-    #   class User < ActiveRecord::Base
-    #     has_secure_password validations: false
-    #   end
-    #
-    #   user = User.new(name: 'david', password: 'mUc3m00RsqyRe')
-    #   user.save
-    #   user.authenticate('notright')      # => false
-    #   user.authenticate('mUc3m00RsqyRe') # => user
-    def authenticate(unencrypted_password)
-      if password_digest.start_with?('$argon2')
-        Argon2::Password.verify_password(unencrypted_password, password_digest, HasSecurePasswordArgon2.secret) && self
-      elsif super(unencrypted_password)
-        self.password = hash_argon2_password(unencrypted_password)
-        save(validate: false)
-        self
-      else
-        false
+      super(*args) if supports_bcrypt_has_secure_password?
+
+      include InstanceMethodsOnActivation.new(attribute)
+
+      if !supports_bcrypt_has_secure_password? && validations
+        include ActiveModel::Validations
+
+        # This ensures the model has a password by checking whether the password_digest
+        # is present, so that this works with both new and existing records. However,
+        # when there is an error, the message is added to the password attribute instead
+        # so that the error message will make sense to the end-user.
+        validate do |record|
+          record.errors.add(attribute, :blank) unless record.send("#{attribute}_digest").present?
+        end
+
+        validates_length_of attribute, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
+        validates_confirmation_of attribute, allow_blank: true
       end
     end
 
-    attr_reader :password
-
-    # Encrypts the password into the +password_digest+ attribute, only if the
-    # new password is not empty.
-    #
-    #   class User < ActiveRecord::Base
-    #     has_secure_password validations: false
-    #   end
-    #
-    #   user = User.new
-    #   user.password = nil
-    #   user.password_digest # => nil
-    #   user.password = 'mUc3m00RsqyRe'
-    #   user.password_digest # => "$2a$10$4LEA7r4YmNHtvlAvHhsYAeZmk/xeUVtMTYqwIvYY76EW5GUqDiP4."
-    def password=(unencrypted_password)
-      if unencrypted_password.nil?
-        self.password_digest = nil
-      elsif !unencrypted_password.empty?
-        @password = unencrypted_password
-        self.password_digest = hash_argon2_password(unencrypted_password)
-      end
-    end
+    alias has_secure has_secure_password
 
     private
 
-    def hash_argon2_password(unencrypted_password)
+    def supports_bcrypt_has_secure_password?
+      require 'bcrypt'
+      true
+    rescue LoadError
+      false
+    end
+  end
+
+  class InstanceMethodsOnActivation < Module
+    def initialize(attribute)
+      attr_reader attribute
+
+      define_method("#{attribute}=") do |unencrypted_password|
+        if unencrypted_password.nil?
+          send("#{attribute}_digest=", nil)
+        elsif !unencrypted_password.empty?
+          instance_variable_set("@#{attribute}", unencrypted_password)
+          send("#{attribute}_digest=", InstanceMethodsOnActivation.generate_secure_hash(unencrypted_password))
+        end
+      end
+
+      define_method("#{attribute}_confirmation=") do |unencrypted_password|
+        instance_variable_set("@#{attribute}_confirmation", unencrypted_password)
+      end
+
+      define_method('authenticate') do |unencrypted_password|
+        attribute_digest = send("#{attribute}_digest")
+
+        if attribute_digest.nil? || attribute_digest.start_with?('$argon2')
+          send("authenticate_#{attribute}", unencrypted_password)
+        elsif defined?(super) && super(unencrypted_password)
+          self.password = InstanceMethodsOnActivation.generate_secure_hash(unencrypted_password)
+          save(validate: false)
+          self
+        else
+          false
+        end
+      end
+
+      # Returns +self+ if the password is correct, otherwise +false+.
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password validations: false
+      #   end
+      #
+      #   user = User.new(name: 'david', password: 'mUc3m00RsqyRe')
+      #   user.save
+      #   user.authenticate_password('notright')      # => false
+      #   user.authenticate_password('mUc3m00RsqyRe') # => user
+      define_method("authenticate_#{attribute}") do |unencrypted_password|
+        begin
+          attribute_digest = send("#{attribute}_digest")
+
+          if attribute_digest.nil? || attribute_digest.start_with?('$argon2')
+            Argon2::Password.verify_password(unencrypted_password, password_digest, HasSecurePasswordArgon2.secret) && self
+          elsif defined?(super) && super(unencrypted_password)
+            self.password = InstanceMethodsOnActivation.generate_secure_hash(unencrypted_password)
+            save(validate: false)
+            self
+          else
+            false
+          end
+        rescue Argon2::ArgonHashFail
+          false
+        end
+      end
+    end
+
+    def self.generate_secure_hash(unencrypted_password)
       hasher = Argon2::Password.new t_cost: HasSecurePasswordArgon2.time_cost,
                                     m_cost: HasSecurePasswordArgon2.memory_cost,
                                     secret: HasSecurePasswordArgon2.secret

--- a/test/has_secure_password_argon2_test.rb
+++ b/test/has_secure_password_argon2_test.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'support/model'
-require 'bcrypt'
+require 'support/models'
 
 class HasSecurePasswordArgon2Test < ActiveSupport::TestCase
-  test 'it has a version number' do
-    refute_nil ::HasSecurePasswordArgon2::VERSION
-  end
-
   test 'password= sets password_digest on a new model' do
     model = Model.new
     model.password = 'abc123'
@@ -32,7 +27,33 @@ class HasSecurePasswordArgon2Test < ActiveSupport::TestCase
   test '#authenticate returns false upon invalid password' do
     model = Model.new(password: 'testing')
 
-    refute model.authenticate('note-testing')
+    refute model.authenticate('not-testing')
+  end
+
+  test '#authenticate returns false if no password was set' do
+    model = Model.new
+
+    refute model.authenticate('nope')
+  end
+
+  test '#authenticate returns false if given a nil password' do
+    model = Model.new(password: 'test')
+
+    refute model.authenticate(nil)
+  end
+
+  test 'allows using different attribute names' do
+    model = ModelWithAttribute.new
+    model.confirmation = 'abc123'
+
+    assert model.confirmation_digest.start_with?('$argon2')
+  end
+
+  test 'allows using shorthand' do
+    model = ModelWithAttributeShorthand.new
+    model.confirmation = 'abc123'
+
+    assert model.confirmation_digest.start_with?('$argon2')
   end
 
   test '#authenticate updates the model for argon2 and returns the model upon valid bcrypt password' do

--- a/test/support/model.rb
+++ b/test/support/model.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class Model < ActiveRecord::Base
-  has_secure_password
-end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Model < ActiveRecord::Base
+  has_secure_password
+end
+
+class ModelWithAttribute < ActiveRecord::Base
+  self.table_name = 'models'
+  has_secure_password :confirmation
+end
+
+class ModelWithAttributeShorthand < ActiveRecord::Base
+  self.table_name = 'models'
+  has_secure :confirmation
+end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -5,5 +5,6 @@ ActiveRecord::Schema.define do
 
   create_table :models, force: true do |t|
     t.string :password_digest
+    t.string :confirmation_digest
   end
 end


### PR DESCRIPTION
This PR ensures:

1. Rails 6 `attribute` parameter is preserved and supported
2. BCrypt is not required to be in the Gemfile to use this gem right out of the box. It is still required to upgrade passwords from bcrypt to argon2, however.
