### PR TITLE
Update method signature for compatibility with rails 6

### DIFF
--- a/lib/has_secure_password_argon2.rb
+++ b/lib/has_secure_password_argon2.rb
@@ -18,8 +18,8 @@ module HasSecurePasswordArgon2
   self.memory_cost = 16 # 1..31
 
   module ClassMethods
-    def has_secure_password(options = {})
-      super options
+    def has_secure_password(*args, **keyw)
+      super
       include InstanceMethodsOnActivation
     end
   end


### PR DESCRIPTION
Trying to use this gem with rails 6.1 I got an `ArgumentError (wrong number of arguments (given 2, expected 0..1))`

After some debugging it turns out that the `has_secure_password` method signature changed in https://github.com/rails/rails/commit/86a48b4da3cbd925d30b0fbe472edbda7171ea9e  

In newer versions of Rails is `has_secure_password(attribute = :password, validations: true)` instead of `has_secure_password(options = {})`

This change makes has_secure_password_argon2 compatible with both method signatures as ["when called without arguments `super` uses the same arguments given to the subclass method"](https://ruby-doc.org/core-3.0.0/doc/syntax/modules_and_classes_rdoc.html#label-Inheritance).